### PR TITLE
feat: Dockerize the socket server

### DIFF
--- a/Dockerfile.socket-server
+++ b/Dockerfile.socket-server
@@ -1,0 +1,24 @@
+FROM node:19-bullseye
+
+ARG SOCKET_SERVER_SSL_CERT_PATH
+ARG SOCKET_SERVER_SSL_KEY_PATH
+
+WORKDIR /usr/src/app
+COPY socket-server/* .
+COPY /util/token-validate.ts .
+COPY $SOCKET_SERVER_SSL_CERT_PATH cert.pem
+COPY $SOCKET_SERVER_SSL_KEY_PATH key.pem
+
+# Expose the websocket server
+EXPOSE 8443
+# Expose the TCP serer
+EXPOSE 8080
+
+# Install dependencies
+RUN yarn
+RUN yarn global add pm2
+
+# Compile the app
+RUN yarn tsc
+
+CMD ["pm2-runtime", "socket-server.js"]

--- a/actions/login.ts
+++ b/actions/login.ts
@@ -2,7 +2,7 @@
 
 import { validateUser } from "@/util/auth";
 import { prisma } from "@/util/prisma";
-import { issueToken } from "@/util/token";
+import { issueToken } from "@/util/token-issue";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 

--- a/actions/signup.ts
+++ b/actions/signup.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createUser, isCreateUserError } from "@/util/auth";
-import { issueToken } from "@/util/token";
+import { issueToken } from "@/util/token-issue";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,14 @@ services:
     restart: always
     ports:
       - "5432:5432"
+
+  socket-server:
+    build:
+      context: .
+      dockerfile: Dockerfile.socket-server
+      args:
+        SOCKET_SERVER_SSL_CERT_PATH: "${SOCKET_SERVER_SSL_CERT_PATH:-socket-server/certificate-localhost.pem}"
+        SOCKET_SERVER_SSL_KEY_PATH: "${SOCKET_SERVER_SSL_KEY_PATH:-socket-server/key-localhost.pem}"
+    ports:
+      - "8080:8080"
+      - "8443:8443"

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { validateToken } from "./util/token";
+import { validateToken } from "./util/token-validate";
 
 export async function middleware(request: NextRequest) {
   const tokenCookie = request.cookies.get("token");

--- a/socket-server/socket-server-web.ts
+++ b/socket-server/socket-server-web.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "fs";
 import { createServer } from "https";
 import { Socket } from "net";
 import { WebSocketServer } from "ws";
-import { validateToken } from "./token.js";
+import { validateToken } from "./token-validate.js";
 import {
   PALETTE_COLORS,
   WebSocketCommandMessage,
@@ -20,8 +20,8 @@ export const createWebSocketServer = (deviceSocketMap: Map<string, Socket>) => {
 
   if (process.env.NODE_ENV === "production") {
     server = createServer({
-      cert: readFileSync(process.env.SOCKET_SERVER_SSL_CERT_PATH!),
-      key: readFileSync(process.env.SOCKET_SERVER_SSL_KEY_PATH!),
+      cert: readFileSync("cert.pem"),
+      key: readFileSync("key.pem"),
     });
   } else {
     port = WEBSOCKET_PORT;

--- a/socket-server/token-validate.ts
+++ b/socket-server/token-validate.ts
@@ -1,0 +1,1 @@
+../util/token-validate.ts

--- a/socket-server/token.ts
+++ b/socket-server/token.ts
@@ -1,1 +1,0 @@
-../util/token.ts

--- a/util/get-authenticated-user.ts
+++ b/util/get-authenticated-user.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/util/prisma";
-import { validateToken } from "@/util/token";
+import { validateToken } from "@/util/token-validate";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 

--- a/util/token-issue.ts
+++ b/util/token-issue.ts
@@ -1,37 +1,7 @@
 import { AuthUser, LiteByte } from "@prisma/client";
 // Using jose instead of jsonwebtoken, because the latter isn't support
 // in nextjs's edge runtime :(
-import {
-  SignJWT,
-  importPKCS8,
-  importSPKI,
-  jwtVerify,
-  type JWTPayload,
-} from "jose";
-
-type CustomJwtPayload = JWTPayload & {
-  scopes: string[];
-  name: string;
-  devices?: Pick<LiteByte, "id" | "serial">[];
-};
-
-/**
- * Validate a JWT token
- * @param token The JWT token to validate
- * @returns The decoded JWT token if it is valid, false otherwise
- */
-export const validateToken = async (token?: string) => {
-  if (!token) return false;
-
-  try {
-    const key = process.env.JWT_PUBLIC_KEY!.replace(/\\n/g, "\n");
-    const parsedKey = await importSPKI(key, "RS256");
-    const { payload } = await jwtVerify(token, parsedKey);
-    return payload as CustomJwtPayload;
-  } catch (e) {
-    return false;
-  }
-};
+import { SignJWT, importPKCS8 } from "jose";
 
 /**
  * Generate a JWT token

--- a/util/token-validate.ts
+++ b/util/token-validate.ts
@@ -1,0 +1,27 @@
+// Using jose instead of jsonwebtoken, because the latter isn't support
+// in nextjs's edge runtime :(
+import { importSPKI, jwtVerify, type JWTPayload } from "jose";
+
+type CustomJwtPayload = JWTPayload & {
+  scopes: string[];
+  name: string;
+  devices?: { id: number; serial: string }[];
+};
+
+/**
+ * Validate a JWT token
+ * @param token The JWT token to validate
+ * @returns The decoded JWT token if it is valid, false otherwise
+ */
+export const validateToken = async (token?: string) => {
+  if (!token) return false;
+
+  try {
+    const key = process.env.JWT_PUBLIC_KEY!.replace(/\\n/g, "\n");
+    const parsedKey = await importSPKI(key, "RS256");
+    const { payload } = await jwtVerify(token, parsedKey);
+    return payload as CustomJwtPayload;
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
Run the socket server within a docker container.

To facilitate this, split the `util/token.ts` which used to handle issuing and validating tokens into separate `token-issue.ts` and `token-validate.ts` files, because the token validation (which is used by the socket server) does not require database access.  By splitting these out, we don't need to add Prisma (and initialize it) within the `socket-server` sub-directory.