### PR TITLE
fix: Allow cookie sharing across subdomains

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,3 +26,7 @@ NEXT_PUBLIC_WEBSOCKET_SERVER_URL=
 # Provide the paths to the certificate and key files here
 SOCKET_SERVER_SSL_CERT_PATH=/path/to/cert.pem
 SOCKET_SERVER_SSL_KEY_PATH=/path/to/key.pem
+
+# The domain used with Set-Cookie header
+# e.g: .your_domain.com
+NEXT_PUBLIC_COOKIE_DOMAIN=

--- a/Dockerfile.socket-server
+++ b/Dockerfile.socket-server
@@ -1,13 +1,10 @@
 FROM node:19-bullseye
 
-ARG SOCKET_SERVER_SSL_CERT_PATH
-ARG SOCKET_SERVER_SSL_KEY_PATH
-
 WORKDIR /usr/src/app
-COPY socket-server/* .
+COPY socket-server/* ./
 COPY /util/token-validate.ts .
-COPY $SOCKET_SERVER_SSL_CERT_PATH cert.pem
-COPY $SOCKET_SERVER_SSL_KEY_PATH key.pem
+COPY socket-server-cert.pem .
+COPY socket-server-key.pem .
 
 # Expose the websocket server
 EXPOSE 8443
@@ -21,4 +18,5 @@ RUN yarn global add pm2
 # Compile the app
 RUN yarn tsc
 
+ENV NODE_ENV=production
 CMD ["pm2-runtime", "socket-server.js"]

--- a/README.md
+++ b/README.md
@@ -46,5 +46,18 @@ Once the database is up, you must grant additional privileges on it to allow Pri
   ```
 - `npx prisma migrate dev` should now work, if/when you need it
 
+## Deployment Details
+The WebSocket and TCP socket servers are run together as a single Node app, the code for which is located in `socket-server/`.  There is a `Dockerfile` and `docker-compose.yml` in the project root which can be used to build and run the server.  
+
+Before you build you **MUST** add a valid SSL certificate and key pair that can be used for the secure websocket server to the project root called: `socket-server-cert.pem` and `socket-server-key.pem`.  In my case they come from LetsEncrypt so to run the server I would clone the repo on my server and run:
+```sh
+$ git clone git@github.com:mhespenh/lite-byte.git
+$ cd lite-byte
+$ sudo cp /etc/letsencrypt/live/mhespenh.com/fullchain.pem socket-server-cert.pem
+$ sudo cp /etc/letsencrypt/live/mhespenh.com/privkey.pem socket-server-key.pem
+$ docker compose build
+$ docker compose up -d
+```
+
 ## License
 This repository is licensed under `GNU General Public License v3.0`.  See [COPYING](COPYING) for the permissions and requirements of this license.

--- a/actions/login.ts
+++ b/actions/login.ts
@@ -34,9 +34,11 @@ export const login = async (
     });
     const token = await issueToken(user);
     cookies().set("token", token, {
+      domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
       path: "/",
       httpOnly: true,
       sameSite: "strict",
+      secure: process.env.NODE_ENV === "production" ? true : undefined,
     });
     redirect("/user");
   } else {

--- a/actions/signup.ts
+++ b/actions/signup.ts
@@ -34,9 +34,11 @@ export const signup = async (
     const token = await issueToken(userOrError);
 
     cookies().set("token", token, {
+      domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
       path: "/",
       httpOnly: true,
       sameSite: "strict",
+      secure: process.env.NODE_ENV === "production" ? true : undefined,
     });
     redirect("/user");
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,11 @@ services:
       - "5432:5432"
 
   socket-server:
+    env_file:
+      - .env
     build:
       context: .
       dockerfile: Dockerfile.socket-server
-      args:
-        SOCKET_SERVER_SSL_CERT_PATH: "${SOCKET_SERVER_SSL_CERT_PATH:-socket-server/certificate-localhost.pem}"
-        SOCKET_SERVER_SSL_KEY_PATH: "${SOCKET_SERVER_SSL_KEY_PATH:-socket-server/key-localhost.pem}"
     ports:
       - "8080:8080"
       - "8443:8443"

--- a/socket-server/socket-server-web.ts
+++ b/socket-server/socket-server-web.ts
@@ -20,8 +20,8 @@ export const createWebSocketServer = (deviceSocketMap: Map<string, Socket>) => {
 
   if (process.env.NODE_ENV === "production") {
     server = createServer({
-      cert: readFileSync("cert.pem"),
-      key: readFileSync("key.pem"),
+      cert: readFileSync("socket-server-cert.pem"),
+      key: readFileSync("socket-server-key.pem"),
     });
   } else {
     port = WEBSOCKET_PORT;


### PR DESCRIPTION
- Fixes the docker configuration for the socket server
- Adds an explicit domain to the `Set-Cookie` call so that cookies are shared correctly in production to subdomains